### PR TITLE
Resolve an issue where on some Android devices the videoSize is not cast correctly

### DIFF
--- a/android/src/main/kotlin/video/api/flutter/livestream/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/video/api/flutter/livestream/MethodCallHandlerImpl.kt
@@ -160,8 +160,8 @@ class MethodCallHandlerImpl(
                 val videoSize = flutterView!!.videoConfig.resolution
                 result.success(
                     mapOf(
-                        "width" to videoSize.width,
-                        "height" to videoSize.height
+                        "width" to videoSize.width.toDouble(),
+                        "height" to videoSize.height.toDouble()
                     )
                 )
             }


### PR DESCRIPTION
On Android if the `videoSizeChanged` event is never triggered the default VideoConfig is used https://github.com/ThibaultBee/StreamPack/blob/main/core/src/main/java/io/github/thibaultbee/streampack/data/VideoConfig.kt#L99, which the width and height are returned as int. To ensure the dart size fields always has a double as expected, we need to `toDouble` here.